### PR TITLE
blktests

### DIFF
--- a/lava-job-template/qemu/qemu-blktests-hd.yaml
+++ b/lava-job-template/qemu/qemu-blktests-hd.yaml
@@ -1,0 +1,75 @@
+# Your first LAVA JOB definition for an riscv_64 QEMU
+device_type: qemu
+job_name: ${qemu_job_name}
+timeouts:
+  job:
+    minutes: 10150
+  action:
+    minutes: 10140
+  connection:
+    minutes: 10
+priority: medium
+visibility: public
+# context allows specific values to be overridden or included
+context:
+  # tell the qemu template which architecture is being tested
+  # the template uses that to ensure that qemu-system-riscv64 is executed.
+  arch: riscv64
+  machine: virt
+  guestfs_interface: virtio
+  extra_options:
+    - -machine virt
+    - -nographic
+    - -smp 8
+    - -m 8G
+    - -device virtio-blk-device,drive=hd0
+    - -append "root=/dev/vda rw console=ttyS0 selinux=0"
+    - -device virtio-net-device,netdev=usernet
+    - -netdev user,id=usernet,hostfwd=tcp::10001-:22
+metadata:
+  # please change these fields when modifying this job for your own tests.
+  format: Lava-Test Test Definition 1.0
+  name: qemu-riscv64-test
+  description: "test for riscv64 qemu"
+  version: "1.0"
+# ACTION_BLOCK
+actions:
+# DEPLOY_BLOCK
+- deploy:
+    timeout:
+      minutes: 20
+    to: tmpfs
+    images:
+      kernel:
+        image_arg: -kernel {kernel}
+        url: ${qemu_kernel_image_url}
+      rootfs:
+        image_arg: -drive file={rootfs},format=raw,id=hd0
+        url: ${qemu_rootfs_image_url}
+      disk:
+        image_arg: -drive file={disk},if=none,id=drv1,format=raw -device virtio-blk-device,drive=drv1
+        url: ${qemu_disk_image_url}
+# BOOT_BLOCK
+- boot:
+    timeout:
+      minutes: 20
+    method: qemu
+    media: tmpfs
+    prompts: ["root@openeuler-riscv64"]
+    auto_login:
+      login_prompt: "openeuler-riscv64 login:"
+      username: root
+      password_prompt: "Password:"
+      password: openEuler12#$
+# TEST_BLOCK
+- test:
+    timeout:
+      minutes: 10100
+    definitions:
+    - repository: ${testcase_repo}
+      from: git
+      name: ${testitem_name}
+      path: ${testcase_url}
+      parameters:
+        TEST_ITEMS: ${test_items}
+        DISK_FILTER: ${disk_filter}

--- a/lava-job-template/qemu/qemu-blktests-mmc.yaml
+++ b/lava-job-template/qemu/qemu-blktests-mmc.yaml
@@ -1,0 +1,75 @@
+# Your first LAVA JOB definition for an riscv_64 QEMU
+device_type: qemu
+job_name: ${qemu_job_name}
+timeouts:
+  job:
+    minutes: 10150
+  action:
+    minutes: 10140
+  connection:
+    minutes: 10
+priority: medium
+visibility: public
+# context allows specific values to be overridden or included
+context:
+  # tell the qemu template which architecture is being tested
+  # the template uses that to ensure that qemu-system-riscv64 is executed.
+  arch: riscv64
+  machine: virt
+  guestfs_interface: virtio
+  extra_options:
+    - -machine virt
+    - -nographic
+    - -smp 8
+    - -m 8G
+    - -device virtio-blk-device,drive=hd0
+    - -append "root=/dev/vda rw console=ttyS0 selinux=0"
+    - -device virtio-net-device,netdev=usernet
+    - -netdev user,id=usernet,hostfwd=tcp::10001-:22
+metadata:
+  # please change these fields when modifying this job for your own tests.
+  format: Lava-Test Test Definition 1.0
+  name: qemu-riscv64-test
+  description: "test for riscv64 qemu"
+  version: "1.0"
+# ACTION_BLOCK
+actions:
+# DEPLOY_BLOCK
+- deploy:
+    timeout:
+      minutes: 20
+    to: tmpfs
+    images:
+      kernel:
+        image_arg: -kernel {kernel}
+        url: ${qemu_kernel_image_url}
+      rootfs:
+        image_arg: -drive file={rootfs},format=raw,id=hd0
+        url: ${qemu_rootfs_image_url}
+      disk:
+        image_arg: -device sdhci-pci -drive file={disk},format=raw,id=mmc -device sd-card,drive=mmc
+        url: ${qemu_disk_image_url}
+# BOOT_BLOCK
+- boot:
+    timeout:
+      minutes: 20
+    method: qemu
+    media: tmpfs
+    prompts: ["root@openeuler-riscv64"]
+    auto_login:
+      login_prompt: "openeuler-riscv64 login:"
+      username: root
+      password_prompt: "Password:"
+      password: openEuler12#$
+# TEST_BLOCK
+- test:
+    timeout:
+      minutes: 10100
+    definitions:
+    - repository: ${testcase_repo}
+      from: git
+      name: ${testitem_name}
+      path: ${testcase_url}
+      parameters:
+        TEST_ITEMS: ${test_items}
+        DISK_FILTER: ${disk_filter}

--- a/lava-job-template/qemu/qemu-blktests-nvme.yaml
+++ b/lava-job-template/qemu/qemu-blktests-nvme.yaml
@@ -1,0 +1,75 @@
+# Your first LAVA JOB definition for an riscv_64 QEMU
+device_type: qemu
+job_name: ${qemu_job_name}
+timeouts:
+  job:
+    minutes: 10150
+  action:
+    minutes: 10140
+  connection:
+    minutes: 10
+priority: medium
+visibility: public
+# context allows specific values to be overridden or included
+context:
+  # tell the qemu template which architecture is being tested
+  # the template uses that to ensure that qemu-system-riscv64 is executed.
+  arch: riscv64
+  machine: virt
+  guestfs_interface: virtio
+  extra_options:
+    - -machine virt
+    - -nographic
+    - -smp 8
+    - -m 8G
+    - -device virtio-blk-device,drive=hd0
+    - -append "root=/dev/vda rw console=ttyS0 selinux=0"
+    - -device virtio-net-device,netdev=usernet
+    - -netdev user,id=usernet,hostfwd=tcp::10001-:22
+metadata:
+  # please change these fields when modifying this job for your own tests.
+  format: Lava-Test Test Definition 1.0
+  name: qemu-riscv64-test
+  description: "test for riscv64 qemu"
+  version: "1.0"
+# ACTION_BLOCK
+actions:
+# DEPLOY_BLOCK
+- deploy:
+    timeout:
+      minutes: 20
+    to: tmpfs
+    images:
+      kernel:
+        image_arg: -kernel {kernel}
+        url: ${qemu_kernel_image_url}
+      rootfs:
+        image_arg: -drive file={rootfs},format=raw,id=hd0
+        url: ${qemu_rootfs_image_url}
+      disk:
+        image_arg: -drive file={disk},format=raw,if=none,id=drv0 -device nvme,drive=drv0,serial=deadbeef
+        url: ${qemu_disk_image_url}
+# BOOT_BLOCK
+- boot:
+    timeout:
+      minutes: 20
+    method: qemu
+    media: tmpfs
+    prompts: ["root@openeuler-riscv64"]
+    auto_login:
+      login_prompt: "openeuler-riscv64 login:"
+      username: root
+      password_prompt: "Password:"
+      password: openEuler12#$
+# TEST_BLOCK
+- test:
+    timeout:
+      minutes: 10100
+    definitions:
+    - repository: ${testcase_repo}
+      from: git
+      name: ${testitem_name}
+      path: ${testcase_url}
+      parameters:
+        TEST_ITEMS: ${test_items}
+        DISK_FILTER: ${disk_filter}

--- a/lava-testcases/common-test/blktests/blktests.sh
+++ b/lava-testcases/common-test/blktests/blktests.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -x
+
+LTP_TMPDIR="/root/blktests-tmp"
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+TEST_ITEMS="block"
+DISK_FILTER="6G"
+RAVA_REPO="
+[openEuler_RAVA_Tools]
+name=openEuler:RAVA:Tools (24.03LTS_SP1)
+type=rpm-md
+baseurl=https://build-repo.tarsier-infra.isrc.ac.cn/home:/yafen:/branches:/openEuler:/RAVA:/Tools/24.03LTS_SP1/
+enabled=1
+gpgcheck=0
+priority=99
+"
+
+while getopts "T:F:" arg; do
+   case "$arg" in
+      T)
+        TEST_ITEMS="${OPTARG}"
+        ;;
+      F)
+        DISK_FILTER="${OPTARG}"
+        ;;
+      ?)
+        echo "Usage: $0 -F <DISK_FILTER> -T <TEST_ITEMS>"
+        exit 1
+        ;;
+   esac
+done
+
+
+parse_blktests_output() {
+    while IFS= read -r line; do
+        if [[ "$line" =~ \[(.*)\] ]]; then
+            status="${BASH_REMATCH[1]}"
+            case "$status" in
+                passed)
+                    new_status="pass"
+                    ;;
+                failed)
+                    new_status="fail"
+                    ;;
+                "not run")
+                    new_status="skip"
+                    ;;
+                *)
+                    new_status="unknown"
+                    ;;
+            esac
+            test_item=${line%%(*}
+            test_item=$(echo $test_item | sed 's/ //g')
+            if [[ "$test_item" == *"=>"* ]]; then
+                test_item="${test_item/=>/(}"
+                test_item="${test_item})"
+            fi
+            echo "${test_item} ${new_status}" >> "${RESULT_FILE}"
+        fi
+    done < "$1"
+}
+
+
+install_blktests() {
+    echo "${RAVA_REPO}" | tee -a /etc/yum.repos.d/openEuler.repo
+    dnf install -y blktests
+}
+
+run_blktests() {
+    cd /usr/lib/blktests
+    mkdir -p "${OUTPUT}"
+
+    DEVICES=$(lsblk | grep "${DISK_FILTER}" | awk '{print $1}')
+    if [ -z "${DEVICES}" ]; then
+        echo Disk of size "${DISK_FILTER}" not detected.
+        exit 1
+    fi
+    TEST_DEVS_STR="TEST_DEVS=("
+    for dev in $DEVICES; do
+        TEST_DEVS_STR="${TEST_DEVS_STR}/dev/$dev "
+    done
+
+    TEST_DEVS_STR="${TEST_DEVS_STR%?})"
+    echo $TEST_DEVS_STR > config
+    echo "QUICK_RUN=1" >> config
+    echo "TIMEOUT=90" >> config
+    cat config
+
+    echo start: ./check "${TEST_ITEMS}" | tee "${OUTPUT}"/blktests.log
+    ./check "${TEST_ITEMS}" | tee "${OUTPUT}"/blktests.log
+    parse_blktests_output "${OUTPUT}"/blktests.log
+    cat "${OUTPUT}"/blktests.log
+    cat "${RESULT_FILE}"
+}
+
+echo "============== Tests to run ==============="
+install_blktests
+echo "blktests install completely"
+run_blktests
+echo "===========End Tests to run ==============="

--- a/lava-testcases/common-test/blktests/blktests.yaml
+++ b/lava-testcases/common-test/blktests/blktests.yaml
@@ -1,0 +1,24 @@
+metadata:
+    name: blktests
+    format: "Lava-Test Test Definition 1.0"
+    description: "Run blktests on openEuler RISC-V"
+    maintainer:
+        - yafen@iscas.ac.cn
+    os:
+        - openEuler-riscv64
+    scope:
+        - blktests functions
+    devices:
+      - qemu
+      - lpi4a
+      - sg2042
+params:
+    TEST_ITEMS: "block"
+    DISK_FILTER: "6G"
+run:
+    steps:
+        - cd lava-testcases/common-test/blktests/
+        - chmod +x blktests.sh
+        - ./blktests.sh -F "${DISK_FILTER}" -T "${TEST_ITEMS}"
+        - chmod +x ../../utils/send-to-lava.sh
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
添加测试用例 blktests，针对测试 MMC、HD、NVMe 三类盘。

@wangliu-iscas 跟以往测试模板不同的是：
1. qemu_disk_image_url：硬盘的 url 链接
2. DISK_FILTER：盘大小，这里默认是 6G，也就是创建盘的大小，建议不要使用 8G 等
3. TEST_ITEMS：测试集，默认 `block`，为空表示测全集
5. 使用 rootfs_img 中需要包含文件夹 `/lib/modules/6.6.0+`，可以从 `/lib/modules/xxx` 拷贝。