### PR TITLE
security: add three testcases

### DIFF
--- a/lava-testcases/security-test/aslr/aslr.sh
+++ b/lava-testcases/security-test/aslr/aslr.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# 检查内核是否启用地址空间布局随机化(ASLR)
+echo "执行测试用例: 检查内核是否启用地址空间布局随机化(ASLR)"
+
+# 执行命令获取当前配置
+result=$(cat /proc/sys/kernel/randomize_va_space 2>/dev/null)
+
+# 检查结果
+if [[ "$result" == "2" ]]; then
+    echo "PASS: ASLR已完全启用，值为: $result"
+    exit 0
+elif [[ "$result" == "1" ]]; then
+    echo "WARNING: ASLR部分启用，值为: $result"
+    echo "建议将ASLR完全启用(值为2)"
+    exit 1
+else
+    echo "FAIL: ASLR未启用，值为: $result"
+    echo "建议启用ASLR(值为2)"
+    exit 1
+fi

--- a/lava-testcases/security-test/aslr/aslr.yaml
+++ b/lava-testcases/security-test/aslr/aslr.yaml
@@ -1,0 +1,22 @@
+metadata:
+    name: aslr
+    format: "Lava-Test Test Definition 1.0"
+    description: "Run aslr tests on openEuler RISC-V"
+    maintainer:
+        - si.yanteng@linux.dev
+    os:
+        - openEuler-riscv64
+    scope:
+        - security
+    devices:
+      - qemu
+      - lpi4a
+      - sg2042
+
+run:
+    steps:
+        - cd lava-testcases/security-test/aslr
+        - chmod +x aslr.sh
+        - ./aslr.sh
+        - chmod +x ../../utils/send-to-lava.sh
+        - ../../utils/send-to-lava.sh ./output/result.txt

--- a/lava-testcases/security-test/mod_sign/Makefile
+++ b/lava-testcases/security-test/mod_sign/Makefile
@@ -1,0 +1,7 @@
+obj-m += hello.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/lava-testcases/security-test/mod_sign/hello.c
+++ b/lava-testcases/security-test/mod_sign/hello.c
@@ -1,0 +1,23 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+// 模块加载函数
+static int __init hello_init(void) {
+    printk(KERN_INFO "Hello, world!\n");
+    return 0;
+}
+
+// 模块卸载函数
+static void __exit hello_exit(void) {
+    printk(KERN_INFO "Goodbye, world!\n");
+}
+
+// 注册模块加载/卸载函数
+module_init(hello_init);
+module_exit(hello_exit);
+
+// 模块描述信息
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("A simple Hello World module");
+MODULE_AUTHOR("Your Name");

--- a/lava-testcases/security-test/mod_sign/mod_sign.sh
+++ b/lava-testcases/security-test/mod_sign/mod_sign.sh
@@ -1,0 +1,12 @@
+make
+insmod hello.ko
+
+# 检查模块是否存在于已加载的模块列表中
+if lsmod | grep -q "^$module_name "; then
+    echo "错误: 内核模块 '$module_name' 已加载" >&2
+    exit 1
+fi
+
+# 如果模块既未加载也不存在，则视为成功
+echo "内核模块 '$module_name' 不存在，测试通过"
+exit 0

--- a/lava-testcases/security-test/mod_sign/mod_sign.yaml
+++ b/lava-testcases/security-test/mod_sign/mod_sign.yaml
@@ -1,0 +1,22 @@
+metadata:
+    name: mod_sign
+    format: "Lava-Test Test Definition 1.0"
+    description: "Run mod_sign tests on openEuler RISC-V"
+    maintainer:
+        - si.yanteng@linux.dev
+    os:
+        - openEuler-riscv64
+    scope:
+        - security
+    devices:
+      - qemu
+      - lpi4a
+      - sg2042
+
+run:
+    steps:
+        - cd lava-testcases/security-test/mod_sign
+        - chmod +x mod_sign.sh
+        - ./mod_sign.sh
+        - chmod +x ../../utils/send-to-lava.sh
+        - ../../utils/send-to-lava.sh ./output/result.txt

--- a/lava-testcases/security-test/syn/syn.sh
+++ b/lava-testcases/security-test/syn/syn.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# 检查内核是否启用SYN洪水保护
+echo "执行测试用例: 检查内核是否启用SYN洪水保护"
+
+# 执行命令获取当前配置
+syncookies=$(cat /proc/sys/net/ipv4/tcp_syncookies 2>/dev/null)
+max_syn_backlog=$(cat /proc/sys/net/ipv4/tcp_max_syn_backlog 2>/dev/null)
+synack_retries=$(cat /proc/sys/net/ipv4/tcp_synack_retries 2>/dev/null)
+
+# 检查结果
+if [[ "$syncookies" == "1" && "$max_syn_backlog" -gt "1024" && "$synack_retries" -le "5" ]]; then
+    echo "PASS: SYN洪水保护已启用且配置合理"
+    echo "  tcp_syncookies: $syncookies"
+    echo "  tcp_max_syn_backlog: $max_syn_backlog"
+    echo "  tcp_synack_retries: $synack_retries"
+    exit 0
+else
+    echo "FAIL: SYN洪水保护配置可能不足"
+    echo "  tcp_syncookies: $syncookies (应设置为1)"
+    echo "  tcp_max_syn_backlog: $max_syn_backlog (建议大于1024)"
+    echo "  tcp_synack_retries: $synack_retries (建议小于等于5)"
+    exit 1
+fi

--- a/lava-testcases/security-test/syn/syn.yaml
+++ b/lava-testcases/security-test/syn/syn.yaml
@@ -1,0 +1,22 @@
+metadata:
+    name: syn
+    format: "Lava-Test Test Definition 1.0"
+    description: "Run syn tests on openEuler RISC-V"
+    maintainer:
+        - si.yanteng@linux.dev
+    os:
+        - openEuler-riscv64
+    scope:
+        - security
+    devices:
+      - qemu
+      - lpi4a
+      - sg2042
+
+run:
+    steps:
+        - cd lava-testcases/security-test/syn
+        - chmod +x syn.sh
+        - ./trinity.sh
+        - chmod +x ../../utils/send-to-lava.sh
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Add syn;
检查内核是否启用SYN洪水保护。
Add asmr;
检查内核是否启用地址空间布局随机化。
Add mod_sign. 
检查内核模块签名功能，构造一个简单的内核模块，尝试插入，正常情况下模块未签名无法插入。

note：请确保编译安装内核时安装了头文件，简单的方法是执行完make module_install后执行make headers_install.